### PR TITLE
Make hexagon imagages into a master hexagon shape

### DIFF
--- a/src/CSS/App.scss
+++ b/src/CSS/App.scss
@@ -1,3 +1,6 @@
 .App {     
     height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }

--- a/src/CSS/HexagonImageBanner.scss
+++ b/src/CSS/HexagonImageBanner.scss
@@ -4,81 +4,87 @@
     margin: 0 auto;
     padding: 0; /* Clears unordered list default of 40px */
 
-    li {
-        list-style-type: none;
-        position: relative;
-        float: left;
-        width: 27.85714285714286%;
-        padding: 0 0 32.16760145166612% 0;
-        -o-transform: rotate(-60deg) skewY(30deg);
-        -moz-transform: rotate(-60deg) skewY(30deg);
-        -webkit-transform: rotate(-60deg) skewY(30deg);
-        -ms-transform: rotate(-60deg) skewY(30deg);
-        transform: rotate(-60deg) skewY(30deg);
-        overflow: hidden;
-        
-        .hexagon {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: #fdbf00;
-            -o-transform: skewY(-30deg) rotate(60deg);
-            -moz-transform: skewY(-30deg) rotate(60deg);
-            -webkit-transform: skewY(-30deg) rotate(60deg);
-            -ms-transform: skewY(-30deg) rotate(60deg);
-            transform: skewY(-30deg) rotate(60deg);
+    .row {
+        display: flex;
+        justify-content: center;
+        margin: -6% 0;
+
+        li {
+            list-style-type: none;
+            position: relative;
+            float: left;
+            width: 27.85714285714286%;
+            padding: 0 0 32.16760145166612% 0;
+            -o-transform: rotate(-60deg) skewY(30deg);
+            -moz-transform: rotate(-60deg) skewY(30deg);
+            -webkit-transform: rotate(-60deg) skewY(30deg);
+            -ms-transform: rotate(-60deg) skewY(30deg);
+            transform: rotate(-60deg) skewY(30deg);
             overflow: hidden;
-            background-size: cover;
-        }
-
-        .lab-with-rose-img {
-            background-image: url('../images/lab-with-rose.jpg');
-        }
-
-        .dog-playing-with-rope-img {
-            background-image: url('../images/dog-playing-with-rope.jpg');
-        }
-
-        .dog-with-glasses-img {
-            background-image: url('../images/dog-with-glasses.jpg');
-        }
-
-        .dog-with-party-hat-img {
-            background-image: url('../images/dog-with-party-hat.jpeg');
-        }
-
-        .dog-and-book-img {
-            background-image: url('../images/dog-and-book.jpg');
-        }
-
-        .dog-and-pie-img {
-            background-image: url('../images/dog-and-pie.jpg');
-        }
-
-        .dog-wearing-glasses-img {
-            background-image: url('../images/dog-wearing-glasses.jpg');
-        }
-
-        .dog-jumping-img {
-            background-image: url('../images/dog-jumping.jpg');
-        }
-
-        .dog-with-frisby-img {
-            background-image: url('../images/dog-with-frisby.jpg');
-        }
-
-        .corgi-dog-img {
-            background-image: url('../images/corgi-dog.jpg');
-        }
-
-        .husky-dog-img {
-            background-image: url('../images/husky-dog.jpg');
-        }
-
-        .dog-with-window-down-img {
-            background-image: url('../images/dog-with-window-down.jpg');
+            
+            .hexagon {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                background: #fdbf00;
+                -o-transform: skewY(-30deg) rotate(60deg);
+                -moz-transform: skewY(-30deg) rotate(60deg);
+                -webkit-transform: skewY(-30deg) rotate(60deg);
+                -ms-transform: skewY(-30deg) rotate(60deg);
+                transform: skewY(-30deg) rotate(60deg);
+                overflow: hidden;
+                background-size: cover;
+            }
+    
+            .lab-with-rose-img {
+                background-image: url('../images/lab-with-rose.jpg');
+            }
+    
+            .dog-playing-with-rope-img {
+                background-image: url('../images/dog-playing-with-rope.jpg');
+            }
+    
+            .dog-with-glasses-img {
+                background-image: url('../images/dog-with-glasses.jpg');
+            }
+    
+            .dog-with-party-hat-img {
+                background-image: url('../images/dog-with-party-hat.jpeg');
+            }
+    
+            .dog-and-book-img {
+                background-image: url('../images/dog-and-book.jpg');
+            }
+    
+            .dog-and-pie-img {
+                background-image: url('../images/dog-and-pie.jpg');
+            }
+    
+            .dog-wearing-glasses-img {
+                background-image: url('../images/dog-wearing-glasses.jpg');
+            }
+    
+            .dog-jumping-img {
+                background-image: url('../images/dog-jumping.jpg');
+            }
+    
+            .dog-with-frisby-img {
+                background-image: url('../images/dog-with-frisby.jpg');
+            }
+    
+            .corgi-dog-img {
+                background-image: url('../images/corgi-dog.jpg');
+            }
+    
+            .husky-dog-img {
+                background-image: url('../images/husky-dog.jpg');
+            }
+    
+            .dog-with-window-down-img {
+                background-image: url('../images/dog-with-window-down.jpg');
+            }
         }
     }
 
@@ -86,22 +92,8 @@
         visibility: visible;
     }
 
-    li:nth-child(3n+2) {
+    li:nth-child(n) {
         margin: 0 1%;
-    }
-
-    li:nth-child(6n+4) { 
-        margin-left: 0.5%;
-    }
-
-    li:nth-child(6n+4), li:nth-child(6n+5), li:nth-child(6n+6) {
-        margin-top: -6.9285714285%;
-        margin-bottom: -6.9285714285%;
-        -o-transform: translateX(50%) rotate(-60deg) skewY(30deg);
-        -moz-transform: translateX(50%) rotate(-60deg) skewY(30deg);
-        -webkit-transform: translateX(50%) rotate(-60deg) skewY(30deg);
-        -ms-transform: translateX(50%) rotate(-60deg) skewY(30deg);
-        transform: translateX(50%) rotate(-60deg) skewY(30deg);
     }
 }
 

--- a/src/components/HexagonImageBanner.js
+++ b/src/components/HexagonImageBanner.js
@@ -4,12 +4,15 @@ function HexagonImageBanner() {
     return (
         <Fragment>
             <ul id="grid" className="clear">
+              <div className="row">
                 <li>
                     <div className="hexagon lab-with-rose-img"></div>
                 </li>
                 <li>
                     <div className="hexagon dog-playing-with-rope-img"></div>
                 </li>
+              </div>
+              <div className="row">
                 <li>
                     <div className="hexagon dog-with-glasses-img"></div>
                 </li>
@@ -17,29 +20,17 @@ function HexagonImageBanner() {
                     <div className="hexagon dog-with-party-hat-img"></div>
                 </li>
                 <li>
-                    <div className="hexagon dog-and-book-img"></div>
-                </li>
-                <li>
-                    <div className="hexagon dog-and-pie-img"></div>
-                </li>
-                <li>
-                    <div className="hexagon dog-wearing-glasses-img"></div>
-                </li>
-                <li>
                     <div className="hexagon dog-jumping-img"></div>
                 </li>
-                <li>
-                    <div className="hexagon dog-with-frisby-img"></div>
-                </li>
-                <li>
-                    <div className="hexagon corgi-dog-img"></div>
-                </li>
+              </div>
+              <div className="row">
                 <li>
                     <div className="hexagon dog-with-window-down-img"></div>
                 </li>
                 <li>
                     <div className="hexagon husky-dog-img"></div>
                 </li>
+              </div>
             </ul>
         </Fragment>
     );


### PR DESCRIPTION
- Remove unneeded hexagon images (total: 12 images => 7 images) in order to make master hexagon shape with 2 images on top, 3 images in the middle, and 2 images on the bottom
- Add divs in HTML to separate each row
- Change SCSS to center grid and flex rows of images
- Adjust proper margin
- Delete unneeded SCSS properties
<img width="1440" alt="pooch-portfolio-master-hexagon" src="https://user-images.githubusercontent.com/40967205/72573257-4d2e3800-3882-11ea-8a8c-87d8f91fb6e3.png">